### PR TITLE
Check for logger config data type and auto-heal if data is invalid

### DIFF
--- a/includes/features/class-dlogger.php
+++ b/includes/features/class-dlogger.php
@@ -204,7 +204,7 @@ class DLogger {
 			$loggers[ DECALOG_SHM_ID ] = $shm;
 			Option::network_set( 'loggers', $loggers );
 		}
-		return Option::network_get( 'loggers' );
+		return $loggers;
 	}
 
 	/**

--- a/includes/features/class-dlogger.php
+++ b/includes/features/class-dlogger.php
@@ -184,6 +184,11 @@ class DLogger {
 	 */
 	private function loggers_check() {
 		$loggers = Option::network_get( 'loggers' );
+		// Verify data structure and fix if required
+		if ( ! is_array( $loggers ) ) {
+			$loggers = array();
+			Option::network_set( 'loggers', $loggers );
+		}
 		// Verify shared memory logger
 		if ( ! array_key_exists( DECALOG_SHM_ID, $loggers ) ) {
 			$shm                       = [];


### PR DESCRIPTION
It's a very basic fix. Smarter solutions are possible but in my oppinion not required. This enforces that all following calls always have an array as they expect which currently is not the case if the option data is malformed.

Fixes #24 