### PR TITLE
Add support for OpenTelemetry span kind

### DIFF
--- a/includes/features/class-dtracer.php
+++ b/includes/features/class-dtracer.php
@@ -402,6 +402,7 @@ class DTracer {
 		$root['localEndpoint']['serviceName'] = 'Main Request';
 		$root['timestamp']                    = (int) ( 1000000 * POWS_START_TIMESTAMP );
 		$root['tags']                         = $this->www_data();
+		$root['kind']                         = 'SERVER';
 		unset( $root['parentId'] );
 		self::$traces_registry['ROOT'] = $root;
 		// Server Init

--- a/includes/handlers/class-abstracttracinghandler.php
+++ b/includes/handlers/class-abstracttracinghandler.php
@@ -306,6 +306,15 @@ abstract class AbstractTracingHandler extends AbstractProcessingHandler {
 				$s['parentSpanId']  = 0;
 				$s['operationName'] = $span['localEndpoint']['serviceName'] . ' [' . str_replace( 'CALL:', '', $span['name'] . ']' );
 			}
+			if ( isset( $span['kind'] ) && is_string( $span['kind'] ) ) {
+				$s['tags'][] = new JTag(
+					[
+						'key'   => 'span.kind',
+						'vType' => JTagType::STRING,
+						'vStr'  => strtolower( $span['kind'] ),
+					]
+				);
+			}
 			if ( isset( $span['tags'] ) && is_array( $span['tags'] ) && 0 < count( $span['tags'] ) ) {
 				foreach ( $span['tags'] as $key => $tag ) {
 					$s['tags'][] = new JTag(


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/blob/52a35899e6ae7e6f85c53aa38bfbfec091b79fac/specification/trace/semantic_conventions/messaging.md?plain=1#L178-L182

This PR adds `span.kind=SERVER` to "Main Request"s for Jaeger and Zipkin formats, to identify them as the entry point of a server application.

Spans whose kind is undefined are equivalent to `INTERNAL`, which indicates they are internal processes called by the server.