### PR TITLE
Fix deprecation warning in PHP8+

### DIFF
--- a/includes/system/class-ip.php
+++ b/includes/system/class-ip.php
@@ -96,7 +96,7 @@ class IP {
 				] as $field
 			) {
 				if ( array_key_exists( $field, $_SERVER ) ) {
-					$ip = self::maybe_extract_ip( explode( ',', filter_input( INPUT_SERVER, $field ) ), 1 === $i );
+					$ip = self::maybe_extract_ip( explode( ',', filter_input( INPUT_SERVER, $field ) ?? '' ), 1 === $i );
 					if ( '' !== $ip ) {
 						return $ip;
 					}


### PR DESCRIPTION
Fixes the following warning on PHP 8+:
```
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in 
.../wp-content/plugins/decalog/includes/system/class-ip.php on line 99
```

which is actually caused by type mismatch. (Superseding https://github.com/Pierre-Lannoy/wp-decalog/pull/46)