### PR TITLE
Add a decalog_error_level_map filter

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -140,3 +140,18 @@ Display advanced settings and controls in admin screens:
 ```php
   add_filter( 'perfopsone_show_advanced', '__return_true' );
 ```
+
+## Error level customization
+PHP error levels are supernumemary compared to the logger levels. The [mapping](https://github.com/Pierre-Lannoy/wp-decalog/blob/3.10.0/includes/listeners/class-phplistener.php#L38-L54) to translate one from the other can be customized with the `decalog_error_level_map` filter.
+
+### Example
+Log the `E_DERECATED` and `E_USER_DEPRECATED` errors as `DEBUG` level.
+```php
+use DLMonolog\Logger;
+
+add_filter('decalog_error_level_map', function($levels) {
+  $levels[E_DEPRECATED] = Logger::DEBUG;
+  $levels[E_USER_DEPRECATED] = Logger::DEBUG;
+  return $levels;
+});
+```

--- a/includes/listeners/class-phplistener.php
+++ b/includes/listeners/class-phplistener.php
@@ -321,7 +321,15 @@ class PhpListener extends AbstractListener {
 	 */
 	public function handle_error( $code, $message, $file = '', $line = 0, $context = [] ) {
 		if ( ! in_array( $code, $this->fatal_errors, true ) ) {
-			$level   = $this->error_level_map[ $code ] ?? Logger::CRITICAL;
+			/**
+			 * Filters the error levels map
+			 *
+			 * @See https://github.com/Pierre-Lannoy/wp-decalog/blob/master/HOOKS.md
+			 * @since 3.11.0
+			 * @param   array   $levels       The current map
+			 */
+			$map = apply_filters( 'decalog_error_level_map', $this->error_level_map );
+			$level = $map[ $code ] ?? Logger::CRITICAL;
 			$file    = PHP::normalized_file_line( $file, $line );
 			$message = sprintf( 'Error (%s): "%s" at `%s`.', $this->code_to_string( $code ), $message, $file );
 			$this->logger->log( $level, $message, (int) $code );


### PR DESCRIPTION
Hello,

Following a discussion started [here](https://wordpress.org/support/topic/how-to-remove-e_deprecated-error-level/), I've achieved to map the php `E_DEPRECATED` level to the logger `DEBUG` level. It is done by adding a filter to customize the levels mapping, so without a filter it remains the same as before.