### PR TITLE
Reduced logging levels for Action Scheduler and WP-CLI --quiet

### DIFF
--- a/includes/listeners/class-libaschedulerlistener.php
+++ b/includes/listeners/class-libaschedulerlistener.php
@@ -137,7 +137,7 @@ class LibASchedulerListener extends AbstractListener {
 	 * @since    2.4.0
 	 */
 	public function action_scheduler_deleted_action( $action_id ) {
-		$this->logger->notice( sprintf( 'Action "%s" (action ID %s) deleted.', \ActionScheduler::store()->fetch_action( $action_id )->get_hook(), $action_id ) );
+		$this->logger->info( sprintf( 'Action "%s" (action ID %s) deleted.', \ActionScheduler::store()->fetch_action( $action_id )->get_hook(), $action_id ) );
 	}
 
 	/**
@@ -191,7 +191,7 @@ class LibASchedulerListener extends AbstractListener {
 	 * @since    2.4.0
 	 */
 	public function action_scheduler_failed_old_action_deletion( $action_id, $exception ) {
-		$this->logger->error( sprintf( 'Unable to delete old action "%s" (action ID %s): %s.', \ActionScheduler::store()->fetch_action( $action_id )->get_hook(), $action_id, ( $exception instanceof \Throwable ? $exception->getMessage() : 'unknown error' ) ) );
+		$this->logger->notice( sprintf( 'Unable to delete old action "%s" (action ID %s): %s.', \ActionScheduler::store()->fetch_action( $action_id )->get_hook(), $action_id, ( $exception instanceof \Throwable ? $exception->getMessage() : 'unknown error' ) ) );
 	}
 
 	/**

--- a/includes/listeners/wp-cli/class-quiet.php
+++ b/includes/listeners/wp-cli/class-quiet.php
@@ -50,7 +50,7 @@ class Quiet extends \WP_CLI\Loggers\Quiet {
 	 * @since 3.6.0
 	 */
 	public function info( $message ) {
-		$this->logger->info( ucfirst( $message ) );
+		$this->logger->debug( ucfirst( $message ) );
 		parent::info( $message );
 	}
 
@@ -61,7 +61,7 @@ class Quiet extends \WP_CLI\Loggers\Quiet {
 	 * @since 3.6.0
 	 */
 	public function success( $message ) {
-		$this->logger->notice( ucfirst( $message ) );
+		$this->logger->debug( ucfirst( $message ) );
 		parent::success( $message );
 	}
 


### PR DESCRIPTION
Hey @Pierre-Lannoy it has been some time and I hope you are doing well as always :-)

As the year passed by and we introduced Action Scheduler to our environment for our own tasks. We realized that the log levels of the current AS listener could be optimized to reduce log bloat.

We run AS using WP-CLI. For context.

In particular in the **AS Listener** we reduced the `deleted` message to info and the `cannot delete` to warning. 

Especially the `cannot delete` can happen frequently due to concurrency when you have multiple cleanup jobs running. But that's not a problem as the error mostly just - correctly - states "maybe deleted already". But I agree it might be an issue as well. Depending on the case. Yet based on our experience I would say that >99,999% of the time the message is not an error and just _expected behaviour_. I would like to move it to `info` but as I said, I do get that this could as well indicate an issue. 

Here is one example of the `cannot delete`
> Unable to delete old action ““ (action ID 1806210): Unidentified action 1806210: we were unable to delete this action. It may may have been deleted by another process.

The `deleted` message pops up for each action when it is done and gets cleaned up. No real added value having this message as `notice`. Especially as only the ID is present as the hook name cannot be retreived anymore when the hook is called. The message looks like this: `Action ““ (action ID 1432896) deleted.`

For **WP-CLI** (when used with `--quiet`) we reduced the log levels to debug for all non warn/error logs. Action Scheduler uses WP-CLI::success after each processing run. Bloating the logs with useless information. In particular `processed 0 tasks`. We tried to run WP-CLI with `--quiet` and expected less logging. But as both classes are identical in Decalog at the moment, that's not the case.

I hope you can follow our rational :-). If not, let's talk about it.

Warm regards,

Jan